### PR TITLE
feat(errors): throw error when command fails

### DIFF
--- a/jbang.js
+++ b/jbang.js
@@ -2,22 +2,33 @@ const shell = require('shelljs');
 const jbang = {};
 jbang.exec = function (...args) {
 	argLine = args.join(" ");
+	let cmdResult = null;
 	if (shell.which('jbang')
 		|| (process.platform === 'win32' && shell.which('./jbang.cmd')) // windows
 		|| shell.which('./jbang')) {
 		console.log('using jbang:', argLine);
-		shell.exec('jbang ' + argLine);
+		cmdResult = shell.exec('jbang ' + argLine);
 	} else if (shell.which('curl') && shell.which('bash')) {
 		console.log('using curl + bash:', argLine);
-		shell.exec('curl -Ls https://sh.jbang.dev | bash -s - ' + argLine);
+		cmdResult = shell.exec('curl -Ls https://sh.jbang.dev | bash -s - ' + argLine);
 	} else if (shell.which('powershell')) {
 		console.log('using powershell:', argLine);
 		shell.exec('echo iex "& { $(iwr -useb https://ps.jbang.dev) } $args" > %TEMP%/jbang.ps1');
-		shell.exec('powershell -Command "%TEMP%/jbang.ps1 ' + argLine + '"');
+		cmdResult = shell.exec('powershell -Command "%TEMP%/jbang.ps1 ' + argLine + '"');
 	} else {
 		shell.echo('unable to pre-install jbang:', argLine);
 		shell.exit(1);
 	}
+
+	if (cmdResult?.code !== 0) {
+		const err = new Error(`The command failed: 'jbang ${argLine}'. Code: ${cmdResult?.code}`);
+		err.code = cmdResult?.code;
+		err.cause = cmdResult.stderr;
+
+		throw err;
+	}
+
+	return cmdResult;
 };
 
 //todo: provide more typesafe/argsafe variations with run...

--- a/test.js
+++ b/test.js
@@ -1,3 +1,11 @@
 #! /usr/bin/env node
 var jbang = require('./jbang');
 jbang.exec('properties@jbangdev');
+
+try {
+    jbang.exec('badinput');
+    console.error('jbang error not caught!');
+    process.exit(1);
+} catch (err) {
+    console.log('jbang error caught successfully');
+}


### PR DESCRIPTION
At the moment, there aren't any good ways of handling errors that occur when a package is executed by jbang. If the exec fails, the code returns normally as if everything was fine.

This PR checks the return code of the execution and throws an error in the event that the command fails (thus making this a breaking / semver major change).

This will be highly useful for projects like `karate-npm` that currently return a `0` on exit even when the test suite execution fails (cc: @ptrthomas).

Let me know if you have any concerns about this implementation. Happy to revise or adjust if desired.