### PR TITLE
(feat) Search for .exe on windows

### DIFF
--- a/jbang.js
+++ b/jbang.js
@@ -54,9 +54,9 @@ function getCommandLine(args) {
 	}
 
 	
-	const path =
+	const path = shell.which('jbang') || 
+		        (process.platform === 'win32' && shell.which('jbang.exe')) |
 			(process.platform === 'win32' && shell.which('jbang.cmd')) || 
-			shell.which('jbang') ||
 			(process.platform === 'win32' && shell.which('~\.jbang\bin\jbang.cmd')) || 
 			shell.which('~/.jbang/bin/jbang') ||
 			null;

--- a/jbang.js
+++ b/jbang.js
@@ -54,12 +54,14 @@ function getCommandLine(args) {
 	}
 
 	
-	const path = shell.which('jbang') || 
-		        (process.platform === 'win32' && shell.which('jbang.exe')) |
-			(process.platform === 'win32' && shell.which('jbang.cmd')) || 
-			(process.platform === 'win32' && shell.which('~\.jbang\bin\jbang.cmd')) || 
+	const path = 
+		    (process.platform === 'win32' &&
+				(shell.which('jbang.exe') ||
+			     shell.which('jbang.cmd') ||
+			     shell.which('~\.jbang\bin\jbang.cmd')) ||
 			shell.which('~/.jbang/bin/jbang') ||
-			null;
+		    shell.which('jbang') ||
+			null);
 	if (path) {
 		debug('found existing jbang installation at %s', path.toString());
 		return [path.toString(),argLine].join(' ');// ensure it is a string not String and append list of arguments


### PR DESCRIPTION
Fixes https://github.com/jbangdev/jbang-npm/issues/20 in a very naive way.

A better solution would do

1. `jbang.exe` found -> store `--version` output
2. `jbang.cmd` found -> store `--version` output
3. If one of them found: use it
4. If both found: use the one with a greater version number